### PR TITLE
Add installation instruction to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ Benchmarks are available under the [`comparisons`](comparisons/) folder.
 - [`rmz`](rmz)
 - [`cpz`](cpz)
 
+## Installation
+
+```
+cargo binstall rmz cpz
+```
+
 ## Goals
 
 1. Performance: if a reasonable improvement can be made, it will be.


### PR DESCRIPTION
Accoding to #7, `rmz` and `cpz` requires nightly compiler to build.
Since nightly sometimes could break code and it requires users to type `cargo +nightly install rmz cpz`, I propose that we could let them use `cargo-binstall` to download from github release artifacts instead.

P.S. I am one of the maintainers of cargo-binstall