### PR TITLE
Remove cargo warning about "no edition set"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ license = "Apache-2.0"
 [package]
 name = "lint"
 version = "0.0.0"
+edition.workspace = true
 publish = false
 
 [dev-dependencies]


### PR DESCRIPTION
Currently, when I run `cargo run` from the `cpz` directory, I get this warning:

```
warning: /homes/noamyr/sand/fuc/Cargo.toml: no edition set: defaulting to the 2015 edition while the latest is 2021
```

I understand that it comes from the `lint` package, which didn't define an edition.

Thanks for cpz and rmz! They already help me a lot.