### PR TITLE
Add -L / --dereference option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ license = "Apache-2.0"
 [package]
 name = "lint"
 version = "0.0.0"
+edition.workspace = true
 publish = false
 
 [dev-dependencies]

--- a/cpz/README.md
+++ b/cpz/README.md
@@ -81,7 +81,7 @@ Options:
           Reverse the argument order so that it becomes `cpz <TO> <FROM>...`
 
   -L, --dereference
-          always follow symbolic links in source
+          Follow symlinks in the files to be copied rather than copying the symlinks themselves
 
   -h, --help
           Print help (use `-h` for a summary)

--- a/cpz/README.md
+++ b/cpz/README.md
@@ -80,6 +80,9 @@ Options:
   -t, --reverse-args
           Reverse the argument order so that it becomes `cpz <TO> <FROM>...`
 
+  -L, --dereference
+          always follow symbolic links in source
+
   -h, --help
           Print help (use `-h` for a summary)
 

--- a/cpz/command-reference-short.golden
+++ b/cpz/command-reference-short.golden
@@ -9,5 +9,6 @@ Arguments:
 Options:
   -f, --force         Overwrite existing files
   -t, --reverse-args  Reverse the argument order so that it becomes `cpz <TO> <FROM>...`
+  -L, --dereference   always follow symbolic links in source
   -h, --help          Print help (use `--help` for more detail)
   -V, --version       Print version

--- a/cpz/command-reference-short.golden
+++ b/cpz/command-reference-short.golden
@@ -9,6 +9,7 @@ Arguments:
 Options:
   -f, --force         Overwrite existing files
   -t, --reverse-args  Reverse the argument order so that it becomes `cpz <TO> <FROM>...`
-  -L, --dereference   always follow symbolic links in source
+  -L, --dereference   Follow symlinks in the files to be copied rather than copying the symlinks
+                      themselves
   -h, --help          Print help (use `--help` for more detail)
   -V, --version       Print version

--- a/cpz/command-reference.golden
+++ b/cpz/command-reference.golden
@@ -20,6 +20,9 @@ Options:
   -t, --reverse-args
           Reverse the argument order so that it becomes `cpz <TO> <FROM>...`
 
+  -L, --dereference
+          always follow symbolic links in source
+
   -h, --help
           Print help (use `-h` for a summary)
 

--- a/cpz/command-reference.golden
+++ b/cpz/command-reference.golden
@@ -21,7 +21,7 @@ Options:
           Reverse the argument order so that it becomes `cpz <TO> <FROM>...`
 
   -L, --dereference
-          always follow symbolic links in source
+          Follow symlinks in the files to be copied rather than copying the symlinks themselves
 
   -h, --help
           Print help (use `-h` for a summary)

--- a/cpz/src/main.rs
+++ b/cpz/src/main.rs
@@ -43,6 +43,10 @@ struct Cpz {
     #[arg(short = 't', long, default_value_t = false)]
     reverse_args: bool,
 
+    /// always follow symbolic links in source
+    #[arg(short = 'L', long, default_value_t = false)]
+    dereference: bool,
+
     #[arg(short, long, short_alias = '?', global = true)]
     #[arg(action = ArgAction::Help, help = "Print help (use `--help` for more detail)")]
     #[arg(long_help = "Print help (use `-h` for a summary)")]
@@ -203,6 +207,7 @@ fn copy(
         mut to,
         force,
         reverse_args,
+        dereference,
         help: _,
     }: Cpz,
 ) -> Result<(), Error> {
@@ -243,6 +248,7 @@ fn copy(
                 (path, to)
             }))
             .force(force)
+            .dereference(dereference)
             .build()
             .run()
     } else {
@@ -261,6 +267,7 @@ fn copy(
                 (from, to)
             }])
             .force(force)
+            .dereference(dereference)
             .build()
             .run()
     }

--- a/cpz/src/main.rs
+++ b/cpz/src/main.rs
@@ -43,8 +43,10 @@ struct Cpz {
     #[arg(short = 't', long, default_value_t = false)]
     reverse_args: bool,
 
-    /// always follow symbolic links in source
+    /// Follow symlinks in the files to be copied rather than copying the
+    /// symlinks themselves
     #[arg(short = 'L', long, default_value_t = false)]
+    #[arg(aliases = ["follow-symlinks"])]
     dereference: bool,
 
     #[arg(short, long, short_alias = '?', global = true)]
@@ -248,7 +250,7 @@ fn copy(
                 (path, to)
             }))
             .force(force)
-            .dereference(dereference)
+            .follow_symlinks(dereference)
             .build()
             .run()
     } else {
@@ -267,7 +269,7 @@ fn copy(
                 (from, to)
             }])
             .force(force)
-            .dereference(dereference)
+            .follow_symlinks(dereference)
             .build()
             .run()
     }

--- a/fuc_engine/api.golden
+++ b/fuc_engine/api.golden
@@ -46,7 +46,7 @@ pub struct fuc_engine::CopyOp<'a, 'b, I1: core::convert::Into<alloc::borrow::Cow
 impl<'a, 'b, I1: core::convert::Into<alloc::borrow::Cow<'a, std::path::Path>> + 'a, I2: core::convert::Into<alloc::borrow::Cow<'b, std::path::Path>> + 'b, F: core::iter::traits::collect::IntoIterator<Item = (I1, I2)>> fuc_engine::CopyOp<'a, 'b, I1, I2, F>
 pub fn fuc_engine::CopyOp<'a, 'b, I1, I2, F>::run(self) -> core::result::Result<(), fuc_engine::Error>
 impl<'a, 'b, I1: core::convert::Into<alloc::borrow::Cow<'a, std::path::Path>> + 'a, I2: core::convert::Into<alloc::borrow::Cow<'b, std::path::Path>> + 'b, F: core::iter::traits::collect::IntoIterator<Item = (I1, I2)>> fuc_engine::CopyOp<'a, 'b, I1, I2, F>
-pub fn fuc_engine::CopyOp<'a, 'b, I1, I2, F>::builder() -> CopyOpBuilder<'a, 'b, I1, I2, F, ((), (), (), ())>
+pub fn fuc_engine::CopyOp<'a, 'b, I1, I2, F>::builder() -> CopyOpBuilder<'a, 'b, I1, I2, F, ((), (), (), (), ())>
 impl<'a, 'b, I1: core::fmt::Debug + core::convert::Into<alloc::borrow::Cow<'a, std::path::Path>> + 'a, I2: core::fmt::Debug + core::convert::Into<alloc::borrow::Cow<'b, std::path::Path>> + 'b, F: core::fmt::Debug + core::iter::traits::collect::IntoIterator<Item = (I1, I2)>> core::fmt::Debug for fuc_engine::CopyOp<'a, 'b, I1, I2, F>
 pub fn fuc_engine::CopyOp<'a, 'b, I1, I2, F>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<'a, 'b, I1, I2, F> core::marker::Freeze for fuc_engine::CopyOp<'a, 'b, I1, I2, F> where F: core::marker::Freeze

--- a/fuc_engine/src/ops/copy.rs
+++ b/fuc_engine/src/ops/copy.rs
@@ -659,20 +659,13 @@ mod compat {
                 }
 
                 let to = to.join(dir_entry.file_name());
-                let file_type = {
-                    #[cfg(unix)]
-                    {
-                        let mut file_type = dir_entry.file_type()?;
-                        if follow_symlinks && file_type.is_symlink() {
-                            file_type = fs::metadata(dir_entry.path())?.file_type();
-                        }
-                        file_type
-                    }
-                    #[cfg(not(unix))]
-                    {
-                        dir_entry.file_type()?
-                    }
-                };
+                #[allow(unused_mut)]
+                let mut file_type = dir_entry.file_type()?;
+                #[cfg(unix)]
+                if follow_symlinks && file_type.is_symlink() {
+                    file_type = fs::metadata(dir_entry.path())?.file_type();
+                }
+                let file_type = file_type;
 
                 #[cfg(unix)]
                 if file_type.is_dir() {

--- a/fuc_engine/src/ops/copy.rs
+++ b/fuc_engine/src/ops/copy.rs
@@ -228,6 +228,7 @@ mod compat {
     #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", skip(tasks)))]
     fn root_worker_thread(tasks: Receiver<TreeNode>, follow_symlinks: bool) -> Result<(), Error> {
         unshare_files()?;
+
         let mut available_parallelism = thread::available_parallelism()
             .map(NonZeroUsize::get)
             .unwrap_or(1)

--- a/fuc_engine/src/ops/copy.rs
+++ b/fuc_engine/src/ops/copy.rs
@@ -39,12 +39,12 @@ pub struct CopyOp<
 }
 
 impl<
-        'a,
-        'b,
-        I1: Into<Cow<'a, Path>> + 'a,
-        I2: Into<Cow<'b, Path>> + 'b,
-        F: IntoIterator<Item = (I1, I2)>,
-    > CopyOp<'a, 'b, I1, I2, F>
+    'a,
+    'b,
+    I1: Into<Cow<'a, Path>> + 'a,
+    I2: Into<Cow<'b, Path>> + 'b,
+    F: IntoIterator<Item = (I1, I2)>,
+> CopyOp<'a, 'b, I1, I2, F>
 {
     /// Consume and run this copy operation.
     ///
@@ -326,7 +326,13 @@ mod compat {
         let from_dir = openat(
             CWD,
             &from,
-            OFlags::RDONLY | OFlags::DIRECTORY | if dereference { OFlags::empty() } else { OFlags::NOFOLLOW },
+            OFlags::RDONLY
+                | OFlags::DIRECTORY
+                | if dereference {
+                    OFlags::empty()
+                } else {
+                    OFlags::NOFOLLOW
+                },
             Mode::empty(),
         )
         .map_io_err(|| format!("Failed to open directory: {from:?}"))?;

--- a/fuc_engine/src/ops/mod.rs
+++ b/fuc_engine/src/ops/mod.rs
@@ -81,9 +81,9 @@ mod linux {
         dir: impl AsFd,
         file_name: &CStr,
         path: &CString,
-        dereference: bool,
+        follow_symlinks: bool,
     ) -> Result<FileType, Error> {
-        let flags = if dereference {
+        let flags = if follow_symlinks {
             AtFlags::empty()
         } else {
             AtFlags::SYMLINK_NOFOLLOW

--- a/fuc_engine/src/ops/mod.rs
+++ b/fuc_engine/src/ops/mod.rs
@@ -81,8 +81,14 @@ mod linux {
         dir: impl AsFd,
         file_name: &CStr,
         path: &CString,
+        dereference: bool,
     ) -> Result<FileType, Error> {
-        statx(dir, file_name, AtFlags::SYMLINK_NOFOLLOW, StatxFlags::TYPE)
+        let flags = if dereference {
+            AtFlags::empty()
+        } else {
+            AtFlags::SYMLINK_NOFOLLOW
+        };
+        statx(dir, file_name, flags, StatxFlags::TYPE)
             .map_io_err(|| {
                 format!(
                     "Failed to stat file: {:?}",

--- a/fuc_engine/src/ops/remove.rs
+++ b/fuc_engine/src/ops/remove.rs
@@ -311,7 +311,7 @@ mod compat {
             }
 
             let file_type = match file.file_type() {
-                FileType::Unknown => get_file_type(&dir, file.file_name(), &node.as_ref().path)?,
+                FileType::Unknown => get_file_type(&dir, file.file_name(), &node.as_ref().path, false)?,
                 t => t,
             };
             if file_type == FileType::Directory {

--- a/fuc_engine/src/ops/remove.rs
+++ b/fuc_engine/src/ops/remove.rs
@@ -311,7 +311,9 @@ mod compat {
             }
 
             let file_type = match file.file_type() {
-                FileType::Unknown => get_file_type(&dir, file.file_name(), &node.as_ref().path, false)?,
+                FileType::Unknown => {
+                    get_file_type(&dir, file.file_name(), &node.as_ref().path, false)?
+                }
                 t => t,
             };
             if file_type == FileType::Directory {

--- a/fuc_engine/tests/copy.rs
+++ b/fuc_engine/tests/copy.rs
@@ -144,3 +144,53 @@ fn symbolic_link_copy_link() {
 
     assert!(to.exists());
 }
+
+#[test]
+#[cfg(unix)]
+fn dereference_symbolic_link_to_regular_file() {
+    let root = tempdir().unwrap();
+    let from = root.path().join("from");
+    fs::create_dir(&from).unwrap();
+    File::create(from.join("file")).unwrap();
+    std::os::unix::fs::symlink("file", from.join("link")).unwrap();
+    let to = root.path().join("to");
+
+    fuc_engine::CopyOp::builder()
+        .files([(Cow::Owned(from), Cow::Borrowed(to.as_path()))])
+        .dereference(true)
+        .build()
+        .run()
+        .unwrap();
+
+    assert!(to.join("file").symlink_metadata().unwrap().is_file());
+    assert!(to.join("link").symlink_metadata().unwrap().is_file());
+}
+
+#[test]
+#[cfg(unix)]
+fn dereference_symbolic_link_to_dir() {
+    let root = tempdir().unwrap();
+    let from = root.path().join("from");
+    fs::create_dir(&from).unwrap();
+    fs::create_dir(from.join("subdir")).unwrap();
+    File::create(from.join("subdir/file")).unwrap();
+    std::os::unix::fs::symlink("subdir", from.join("subdirlink")).unwrap();
+    let to = root.path().join("to");
+
+    fuc_engine::CopyOp::builder()
+        .files([(Cow::Owned(from), Cow::Borrowed(to.as_path()))])
+        .dereference(true)
+        .build()
+        .run()
+        .unwrap();
+
+    assert!(to.join("subdir").symlink_metadata().unwrap().is_dir());
+    assert!(to.join("subdir/file").symlink_metadata().unwrap().is_file());
+    assert!(to.join("subdirlink").symlink_metadata().unwrap().is_dir());
+    assert!(
+        to.join("subdirlink/file")
+            .symlink_metadata()
+            .unwrap()
+            .is_file()
+    );
+}


### PR DESCRIPTION
Hi,

I added an equivalent to `cp -L` = `cp --dereference` option. I need this for my work, where I want to replace a `cp` command on NFS which takes forever, and it's using `-L`. I tried to make it behave like `cp -L` does: just treat symlinks as if they were really the files or directories they refer to. FWIW, in my work I was able to replace the `cp -rL` with `cpz -L`, and it succeeded, reducing the copying time from 49 minutes to 4 minutes!

WDYT?

